### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Government.
 - `Product Documentation`_
 
 .. |beta| image:: https://img.shields.io/badge/support-beta-orange.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#beta-support
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#beta-support
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-assured-workloads.svg
    :target: https://pypi.org/project/google-cloud-assured-workloads/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-assured-workloads.svg
@@ -81,4 +81,4 @@ Next Steps
    APIs that we cover.
 
 .. _Assured Workloads API Product documentation:  https://cloud.google.com/workflows/docs
-.. _README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.